### PR TITLE
diagnose explorer issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ poetry.lock
 .coverage
 coverage.xml
 .vscode/
+*.png

--- a/nrpt/adaptation.py
+++ b/nrpt/adaptation.py
@@ -75,25 +75,22 @@ def adapt_explorers(kernel, pt_state):
         pt_state.replica_states
     )
 
-    # to avoid https://github.com/Estep-Bingham-Lab/nrpt/issues/5
-    #   - force fitted step size >=20% of mean across chains 
-    #   - force all to use the base preconditioner for the target
-    n_replicas = len(replica_states.base_step_size)
+    # postprocess
+    #   - force fitted step size >=1% of mean across chains 
+    #   - NOT USED: force all to use the base preconditioner for the target
+    # n_replicas = len(replica_states.base_step_size)
     mean_base_step_size = replica_states.base_step_size.mean()
-    target_replica_idx = pt_state.chain_to_replica_idx[-1]
-    target_prec_state = jax.tree.map(
-        itemgetter(target_replica_idx), replica_states.base_precond_state
-    )
+    # target_replica_idx = pt_state.chain_to_replica_idx[-1]
+    # target_prec_state = jax.tree.map(
+    #     itemgetter(target_replica_idx), replica_states.base_precond_state
+    # )
     replica_states = replica_states._replace(
         base_step_size = lax.max(
-            replica_states.base_step_size, 0.2*mean_base_step_size
+            replica_states.base_step_size, 0.01*mean_base_step_size
         ),
-        base_precond_state = jax.tree.map(
-            lambda x: lax.broadcast(x, (n_replicas,)),
-            target_prec_state
-        )
+        # base_precond_state = jax.tree.map(
+        #     lambda x: lax.broadcast(x, (n_replicas,)),
+        #     target_prec_state
+        # )
     )
-
-    # new_replica_states = new_replica_states._replace(base_precond_state=base_precond_state)
-    # new_replica_states = new_replica_states._replace(base_step_size=base_step_size)
     return pt_state._replace(replica_states = replica_states)

--- a/nrpt/adaptation.py
+++ b/nrpt/adaptation.py
@@ -1,7 +1,11 @@
 from functools import partial
+from operator import itemgetter
 
 import jax
 from jax import numpy as jnp
+from jax import lax
+
+from autostep import autostep
 
 from nrpt import interpolation
 
@@ -63,7 +67,33 @@ def adapt_explorers(kernel, pt_state):
     """
     Adapt the exploration kernels.
     """
-    new_replica_states = jax.vmap(partial(kernel.adapt, force=True))(
+    if not isinstance(kernel, autostep.AutoStep):
+        return pt_state
+    
+    # start by triggering `adapt` on all replicas
+    replica_states = jax.vmap(partial(kernel.adapt, force=True))(
         pt_state.replica_states
     )
-    return pt_state._replace(replica_states = new_replica_states)
+
+    # to avoid https://github.com/Estep-Bingham-Lab/nrpt/issues/5
+    #   - force fitted step size >=20% of mean across chains 
+    #   - force all to use the base preconditioner for the target
+    n_replicas = len(replica_states.base_step_size)
+    mean_base_step_size = replica_states.base_step_size.mean()
+    target_replica_idx = pt_state.chain_to_replica_idx[-1]
+    target_prec_state = jax.tree.map(
+        itemgetter(target_replica_idx), replica_states.base_precond_state
+    )
+    replica_states = replica_states._replace(
+        base_step_size = lax.max(
+            replica_states.base_step_size, 0.2*mean_base_step_size
+        ),
+        base_precond_state = jax.tree.map(
+            lambda x: lax.broadcast(x, (n_replicas,)),
+            target_prec_state
+        )
+    )
+
+    # new_replica_states = new_replica_states._replace(base_precond_state=base_precond_state)
+    # new_replica_states = new_replica_states._replace(base_step_size=base_step_size)
+    return pt_state._replace(replica_states = replica_states)

--- a/nrpt/exploration.py
+++ b/nrpt/exploration.py
@@ -7,6 +7,8 @@ from jax import numpy as jnp
 from numpyro.handlers import seed, trace
 from numpyro.infer import util
 
+from autostep import autostep
+
 # sample from prior using NumPyro handlers
 def sample_from_prior(model, model_args, model_kwargs, rng_key):
     traced_model = trace(seed(model, rng_seed=rng_key))
@@ -25,6 +27,9 @@ def sample_iid_kernel_state(
         model_kwargs, 
         kernel_state
     ):
+    if not isinstance(kernel, autostep.AutoStep):
+        return kernel_state
+
     # sample from the prior in unconstraiend space
     new_rng_key, iid_key = jax.random.split(kernel_state.rng_key)
     unconstrained_sample = sample_from_prior(

--- a/nrpt/exploration.py
+++ b/nrpt/exploration.py
@@ -2,37 +2,92 @@ from functools import partial
 
 import jax
 from jax import lax
+from jax import numpy as jnp
+
+from numpyro.handlers import seed, trace
+from numpyro.infer import util
+
+# sample from prior using NumPyro handlers
+def sample_from_prior(model, model_args, model_kwargs, rng_key):
+    traced_model = trace(seed(model, rng_seed=rng_key))
+    unconstrain = partial(util.unconstrain_fn, model, model_args, model_kwargs)
+    exec_trace = traced_model.get_trace(*model_args, **model_kwargs)
+    params = {
+        name: site["value"] for name, site in exec_trace.items() 
+        if site["type"] == "sample" and not site["is_observed"]
+    }
+    return unconstrain(params)
+
+# make a new kernel state by refreshing the sample field from the prior
+def sample_iid_kernel_state(
+        kernel,
+        model_args, 
+        model_kwargs, 
+        kernel_state
+    ):
+    # sample from the prior in unconstraiend space
+    new_rng_key, iid_key = jax.random.split(kernel_state.rng_key)
+    unconstrained_sample = sample_from_prior(
+        kernel.model, model_args, model_kwargs, iid_key
+    )
+
+    # store sample
+    kernel_state = kernel_state._replace(
+        rng_key=new_rng_key, **{kernel.sample_field: unconstrained_sample}
+    )
+
+    # update logprobs and return
+    return kernel.update_log_joint(
+        kernel_state, kernel_state.base_precond_state
+    )
 
 # sequentially sample multiple times, discard intermediate states
-def loop_sample(kernel, init_state, n_refresh, model_args, model_kwargs):
+def loop_sample(kernel, n_refresh, model_args, model_kwargs, kernel_state):
     """
     Performs `n_refresh` Markov steps with the provided kernel, returning
     only the last state of the chain.
     
     :param kernel: An instance of `numpyro.infer.MCMC`.
-    :param init_state: Starting point of the sampler.
     :param n_refresh: Number of Markov steps to take with the sampler.
     :param model_args: Model arguments.
     :param model_kwargs: Model keyword arguments.
+    :param kernel_state: Starting point of the sampler.
     :return: The last state of the chain.
     """
     return lax.scan(
-        lambda state, _: (kernel.sample(state,model_args,model_kwargs), None), 
-        init_state,
+        lambda state, _: (kernel.sample(state,model_args,model_kwargs), None),
+        kernel_state,
         length=n_refresh
     )[0]
 
-# TODO: do iid sampling at chain_idx=0
+def explore(
+        kernel, 
+        n_refresh, 
+        model_args, 
+        model_kwargs, 
+        kernel_state, 
+        chain_idx
+    ):
+    """
+    Sample iid from prior if replica is targeting the reference chain; 
+    otherwise, take `n_refresh` MCMC steps.
+    """
+    return lax.cond(
+        jnp.logical_and(kernel.model is not None, chain_idx == 0),
+        partial(sample_iid_kernel_state, kernel, model_args, model_kwargs),
+        partial(loop_sample, kernel, n_refresh, model_args, model_kwargs),
+        kernel_state
+    )
+
 def exploration_step(kernel, pt_state, n_refresh, model_args, model_kwargs):
-    vmap_loop_sample = jax.vmap(
-        partial(
-            loop_sample, 
-            kernel, 
-            n_refresh=n_refresh, 
-            model_args=model_args, 
-            model_kwargs=model_kwargs
-        )
+    """
+    Exploration step vectorized over replicas.
+    """
+    vmap_explore = jax.vmap(
+        partial(explore, kernel, n_refresh, model_args, model_kwargs)
     )
     return pt_state._replace(
-        replica_states = vmap_loop_sample(pt_state.replica_states)
+        replica_states = vmap_explore(
+            pt_state.replica_states, pt_state.replica_to_chain_idx
+        )
     )

--- a/nrpt/sampling.py
+++ b/nrpt/sampling.py
@@ -2,8 +2,11 @@ from functools import partial
 
 import jax
 from jax import lax
+from jax import numpy as jnp
 
 from numpyro import util
+
+from autostep import autostep
 
 from nrpt import adaptation
 from nrpt import exploration
@@ -15,6 +18,11 @@ def n_scans_in_round(round_idx):
 
 def total_scans(n_rounds):
     return 2 ** (n_rounds+1) - 2
+
+def get_explorer_mean_acc_prob(kernel, pt_state):
+    if not isinstance(kernel, autostep.AutoStep):
+        return jnp.array([1.])
+    return pt_state.replica_states.stats.adapt_stats.mean_acc_prob
 
 def total_barrier(barrier_fit):
     return barrier_fit.y[-1]
@@ -73,10 +81,37 @@ def maybe_store_sample(kernel, model_args, model_kwargs, pt_state, n_rounds):
         pt_state
     )
 
+def print_summary_header():
+    jax.debug.print(
+        " Round | Λ     | logZ      | ρ (mean/max) | α (min/mean) \n" \
+        "---------------------------------------------------------",
+        ordered=True
+    )
+    return
+
+def print_round_summary(ending_round_idx, explorer_mean_acc_prob, pt_state):
+    # print a header in first round
+    lax.cond(ending_round_idx == 1, print_summary_header, lambda: None)
+
+    # print row 
+    jax.debug.print(
+        " {i}       {b:.1f}     {lZ: .2e}    {rm:.1f}/{rM:.1f}      {am:.1f}/{aM:.1f}",
+        ordered=True,
+        i=ending_round_idx,
+        b=total_barrier(pt_state.stats.barrier_fit),
+        lZ=logZ_at_target(pt_state.stats.logZ_fit),
+        rm=pt_state.stats.last_round_rej_probs.mean(),
+        rM=pt_state.stats.last_round_rej_probs.max(),
+        am=explorer_mean_acc_prob.min(),
+        aM=explorer_mean_acc_prob.mean()
+    )
+
 def postprocess_round(kernel, pt_state):
     ending_round_idx = pt_state.stats.round_idx
 
     # adapt explorers
+    # capture acc probs before they are deleted
+    explorer_mean_acc_prob = get_explorer_mean_acc_prob(kernel, pt_state)
     pt_state = adaptation.adapt_explorers(kernel, pt_state)
     
     # adapt schedule
@@ -86,16 +121,7 @@ def postprocess_round(kernel, pt_state):
     pt_state = statistics.end_of_round_stats_update(pt_state, barrier_fit)
 
     # print info
-    # TODO: print a header before the fist call to this (in `run`?)
-    jax.debug.print(
-        "Round {i} \t Λ = {b:.2f} \t logZ = {lZ: .2f} \t RejProbs (mean/max) = {rm:.1f}/{rM:.1f}",
-        ordered=True,
-        i=ending_round_idx,
-        b=total_barrier(barrier_fit),
-        lZ=logZ_at_target(pt_state.stats.logZ_fit),
-        rm=pt_state.stats.last_round_rej_probs.mean(),
-        rM=pt_state.stats.last_round_rej_probs.max()
-    )
+    print_round_summary(ending_round_idx, explorer_mean_acc_prob, pt_state)
 
     return pt_state
 

--- a/nrpt/sampling.py
+++ b/nrpt/sampling.py
@@ -1,4 +1,5 @@
 from functools import partial
+from operator import itemgetter
 
 import jax
 from jax import lax
@@ -39,10 +40,7 @@ def extract_sample(
         extra_fields = ('log_lik', 'log_posterior', 'log_joint')
     ):
     # grab the state of the requested replica
-    target_replica_state = jax.tree.map(
-        lambda x: x[replica_idx], 
-        replica_states
-    )
+    target_replica_state = jax.tree.map(itemgetter(replica_idx), replica_states)
 
     # extract the kernel's sample field, then constrain the sample
     unconstrained_sample = getattr(target_replica_state, kernel.sample_field)
@@ -83,7 +81,7 @@ def maybe_store_sample(kernel, model_args, model_kwargs, pt_state, n_rounds):
 
 def print_summary_header():
     jax.debug.print(
-        " Round | Λ     | logZ      | ρ (mean/max) | α (min/mean) \n" \
+        " Round |     Λ |      logZ | ρ (mean/max) | α (min/mean) \n" \
         "---------------------------------------------------------",
         ordered=True
     )
@@ -95,7 +93,7 @@ def print_round_summary(ending_round_idx, explorer_mean_acc_prob, pt_state):
 
     # print row 
     jax.debug.print(
-        " {i}       {b:.1f}     {lZ: .2e}    {rm:.1f}/{rM:.1f}      {am:.1f}/{aM:.1f}",
+        " {i:>5}     {b:.1f}   {lZ: .2e}        {rm:.1f}/{rM:.1f}        {am:.1f}/{aM:.1f}",
         ordered=True,
         i=ending_round_idx,
         b=total_barrier(pt_state.stats.barrier_fit),

--- a/nrpt/sampling.py
+++ b/nrpt/sampling.py
@@ -23,7 +23,9 @@ def total_scans(n_rounds):
 def get_explorer_mean_acc_prob(kernel, pt_state):
     if not isinstance(kernel, autostep.AutoStep):
         return jnp.array([1.])
-    return pt_state.replica_states.stats.adapt_stats.mean_acc_prob
+    # sort by chain and exclude the first (no exploration, only iid sampling)
+    replica_acc_probs = pt_state.replica_states.stats.adapt_stats.mean_acc_prob
+    return replica_acc_probs[pt_state.chain_to_replica_idx[1:]]
 
 def total_barrier(barrier_fit):
     return barrier_fit.y[-1]

--- a/tests/test_toy_models.py
+++ b/tests/test_toy_models.py
@@ -30,7 +30,7 @@ class TestToyExamples(unittest.TestCase):
             kernel, 
             rng_key,
             n_replicas=math.ceil(2*true_barrier),
-            n_rounds = 12,
+            n_rounds = 10,
             model_args=model_args,
             model_kwargs=model_kwargs
         )
@@ -51,7 +51,7 @@ class TestToyExamples(unittest.TestCase):
 
         # check base step size decreases with inv_temp
         self.assertTrue(testutils.is_increasing(
-            -pt_state.replica_states.base_step_size[pt_state.chain_to_replica_idx]
+            -pt_state.replica_states.base_step_size[pt_state.chain_to_replica_idx[1:]]
         ))
 
         # check samples

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
 from jax import numpy as jnp
+from jax import random
 
 from numpyro import infer
 
@@ -16,6 +17,11 @@ NoneState = namedtuple('NoneState', ['log_lik', 'inv_temp'])
 class NoneExplorer(infer.mcmc.MCMCKernel):
     def __init__(self, *args, **kwargs):
         self._potential_fn = lambda _: jnp.float32(0)
+        self._model = None
+    
+    @property
+    def model(self):
+        return self._model
 
     def init(self, *args, **kwargs):
         return NoneState(log_lik=jnp.float32(0), inv_temp=jnp.float32(1))


### PR DESCRIPTION
Fixes #5 

EDIT: any choice of adaptation has a drawback. The underlying issues is that autoMALA works great on a single mode. But when adaptation is done to incorporate both modes, the performance degrades and AM is only able to explore in spatters. The sampler now
- adapts all preconditioners separately for each chain
- same for step size but these are capped from below to 1% of average step size.